### PR TITLE
Fix array hashing implementations

### DIFF
--- a/Python/Arrays and hashing/2sum.py
+++ b/Python/Arrays and hashing/2sum.py
@@ -1,17 +1,19 @@
+from typing import List
+
+
 class Solution:
     def twoSum(self, nums: List[int], target: int) -> List[int]:
         if len(nums) == 2:
             if nums[0] + nums[1] != target:
                 return []
             else:
-                return [0,1]  
-        n = len(nums)-1
-        count =0 
+                return [0, 1]
+        n = len(nums) - 1
+        count = 0
         for i in range(n):
             count += 1
-            if(target-nums[i] in nums[i+1:]):
-                new_nums = nums[i+1:]
-                return [i,new_nums.index(target-nums[i])+count]
-
+            if (target - nums[i]) in nums[i + 1:]:
+                new_nums = nums[i + 1:]
+                return [i, new_nums.index(target - nums[i]) + count]
 
         return []

--- a/Python/Arrays and hashing/TopkfrequentElement.py
+++ b/Python/Arrays and hashing/TopkfrequentElement.py
@@ -1,3 +1,7 @@
+from typing import List
+from collections import Counter
+
+
 class Solution:
-    def topKFrequent(self,nums:List[int],k:int)->List[int]:
-        return [x[0] for x in Counter(nums).most_common(k)]             
+    def topKFrequent(self, nums: List[int], k: int) -> List[int]:
+        return [x[0] for x in Counter(nums).most_common(k)]

--- a/Python/Arrays and hashing/arrays_duplicate_easy.py
+++ b/Python/Arrays and hashing/arrays_duplicate_easy.py
@@ -1,6 +1,9 @@
+from typing import List
+
+
 class Solution:
     def containsDuplicate(self, nums: List[int]) -> bool:
-        dict_new={}
+        dict_new = {}
         for i in nums:
             if i in dict_new:
                 dict_new[i] += 1
@@ -9,5 +12,5 @@ class Solution:
         for j in dict_new:
             if dict_new[j] > 1:
                 return True
-            
+
         return False

--- a/Python/Arrays and hashing/group_anagram_medium.py
+++ b/Python/Arrays and hashing/group_anagram_medium.py
@@ -1,17 +1,10 @@
+from typing import List
+from collections import defaultdict
+
+
 class Solution:
     def groupAnagrams(self, strs: List[str]) -> List[List[str]]:
-        # Create a dictionary to act as hashmap
-        res = {}
+        res = defaultdict(list)
         for word in strs:
-            # We want to retain the original word to add to the dictionary
-            # Therefore, create a temporary variable with the sorted word
-            temp = ''.join(sorted(word))
-            # If the sorted word exists in the dictionary, 
-            # append to the values list
-            if temp in res:
-                res[temp].append(word)
-            # Else, add a new key-value pair to the dictionary
-            else:
-                res[temp] = [word]
-        # We only require the values list to be returned
-        return res.values()
+            res[''.join(sorted(word))].append(word)
+        return list(res.values())

--- a/Python/Arrays and hashing/valid_anagram.py
+++ b/Python/Arrays and hashing/valid_anagram.py
@@ -2,13 +2,13 @@ class Solution:
     def isAnagram(self, s: str, t: str) -> bool:
         if len(s) != len(t):
             return False
-        s_list =[]
-        t_list =[]
+        s_list = []
+        t_list = []
         for i in s:
             s_list.append(i)
         for j in t:
             t_list.append(j)
-        
+
         s_list.sort()
         t_list.sort()
         if s_list == t_list:


### PR DESCRIPTION
## Summary
- add missing typing and collections imports to array/hash solution files
- ensure groupAnagrams returns concrete lists using defaultdict
- normalize algorithms with consistent formatting

## Testing
- `python - <<'PY'
import runpy, os
base = 'Python/Arrays and hashing'
sol_two = runpy.run_path(os.path.join(base, '2sum.py'))['Solution']()
print('twoSum:', sol_two.twoSum([2,7,11,15],9))
sol_dup = runpy.run_path(os.path.join(base, 'arrays_duplicate_easy.py'))['Solution']()
print('containsDuplicate:', sol_dup.containsDuplicate([1,2,3,1]))
sol_group = runpy.run_path(os.path.join(base, 'group_anagram_medium.py'))['Solution']()
print('groupAnagrams:', [sorted(g) for g in sol_group.groupAnagrams(["eat","tea","tan","ate","nat","bat"])])
sol_topk = runpy.run_path(os.path.join(base, 'TopkfrequentElement.py'))['Solution']()
print('topKFrequent:', sol_topk.topKFrequent([1,1,1,2,2,3],2))
sol_valid = runpy.run_path(os.path.join(base, 'valid_anagram.py'))['Solution']()
print('isAnagram:', sol_valid.isAnagram('anagram', 'nagaram'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6896cba95a148332a75cf260f8a6dc1c